### PR TITLE
47 sync logic preserve directories removed from config

### DIFF
--- a/BackupUtilityCore/BackupUtilityCore.csproj
+++ b/BackupUtilityCore/BackupUtilityCore.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <Copyright>Copyright © 2020-2026 Alan Barr</Copyright>
     <Authors>Alan Barr (GitHub: freedom35)</Authors>
     <Description>Command line backup utility targeting .NET</Description>

--- a/BackupUtilityCore/Tasks/BackupTaskBase.cs
+++ b/BackupUtilityCore/Tasks/BackupTaskBase.cs
@@ -461,6 +461,21 @@ namespace BackupUtilityCore.Tasks
         }
 
         /// <summary>
+        /// Gets the equivalent target directory for a source directory.
+        /// </summary>
+        /// <param name="sourceDir">Name of source directory</param>
+        /// <param name="targetDir">Name of target directory</param>
+        /// <returns>Full path of target directory</returns>
+        protected static string GetTargetDirForSourceDir(string sourceDir, string targetDir)
+        {
+            // Remove common root path between source and target
+            string subDir = GetSourceSubDir(sourceDir, targetDir);
+
+            // Append source sub-dir to target
+            return Path.Combine(targetDir, subDir);
+        }
+
+        /// <summary>
         /// Gets the directory name where the source starts.
         /// </summary>
         /// <param name="sourceDir">Name of source directory</param>

--- a/BackupUtilityCore/Tasks/BackupTaskCopy.cs
+++ b/BackupUtilityCore/Tasks/BackupTaskCopy.cs
@@ -61,11 +61,8 @@ namespace BackupUtilityCore.Tasks
             // (Files within a hidden directory are also considered hidden.)
             if (!BackupSettings.IgnoreHiddenFiles || (sourceDirInfo.Attributes & FileAttributes.Hidden) == 0)
             {
-                // Remove common root path
-                string sourceSubDir = GetSourceSubDir(sourceDirInfo.FullName, targetDirInfo.FullName);
-
                 // Get target path
-                string targetDir = Path.Combine(targetDirInfo.FullName, sourceSubDir);
+                string targetDir = GetTargetDirForSourceDir(sourceDirInfo.FullName, targetDirInfo.FullName);
 
                 // Get qualifying files only
                 var files = Directory.EnumerateFiles(sourceDirInfo.FullName, "*.*", SearchOption.TopDirectoryOnly).Where(f => !BackupSettings.IsFileTypeExcluded(f));

--- a/BackupUtilityCore/Tasks/BackupTaskSync.cs
+++ b/BackupUtilityCore/Tasks/BackupTaskSync.cs
@@ -13,9 +13,9 @@ namespace BackupUtilityCore.Tasks
         protected override BackupType BackupType => BackupType.Sync;
 
         /// <summary>
-        /// Target location of source directories
+        /// Target locations of source directories
         /// </summary>
-        private string[] sourceDirsInTarget = [];
+        private string[] targetDirs = [];
 
         /// <summary>
         /// Syncs target directory with source directories.
@@ -23,11 +23,11 @@ namespace BackupUtilityCore.Tasks
         /// <returns>Number of new files backed up</returns>
         protected override int PerformBackup()
         {
-            string targetDir = BackupSettings.TargetDirectory;
+            string rootTargetDir = BackupSettings.TargetDirectory;
 
-            AddToLog("TARGET", targetDir);
+            AddToLog("TARGET", rootTargetDir);
 
-            DirectoryInfo targetDirInfo = new(targetDir);
+            DirectoryInfo targetDirInfo = new(rootTargetDir);
 
             // Check to create target directory
             if (!targetDirInfo.Exists)
@@ -38,10 +38,10 @@ namespace BackupUtilityCore.Tasks
             int backupCount = 0;
 
             // Get target location of source directories
-            sourceDirsInTarget = GetSourceSubDirs(BackupSettings.SourceDirectories, targetDir);
+            targetDirs = GetTargetDirsFromSourceDirs(BackupSettings.SourceDirectories, rootTargetDir);
 
             // Should be same, but safety check
-            int maxSource = Math.Min(BackupSettings.SourceDirectories.Length, sourceDirsInTarget.Length);
+            int maxSource = Math.Min(BackupSettings.SourceDirectories.Length, targetDirs.Length);
 
             // Sync each source directory
             for (int i = 0; i < maxSource; i++)
@@ -51,7 +51,7 @@ namespace BackupUtilityCore.Tasks
                 AddToLog("SOURCE", sourceDir);
 
                 // Sync within the source directories
-                backupCount += SyncDirectories(sourceDir, sourceDirsInTarget[i]);
+                backupCount += SyncDirectories(sourceDir, targetDirs[i]);
             }
 
             return backupCount;
@@ -60,17 +60,17 @@ namespace BackupUtilityCore.Tasks
         /// <summary>
         /// Gets the sub directory where each source will be located in the target directory.
         /// </summary>
-        private static string[] GetSourceSubDirs(string[] sourceDirectories, string targetDir)
+        private static string[] GetTargetDirsFromSourceDirs(string[] sourceDirectories, string rootTargetDir)
         {
             List<string> dirs = [];
 
             foreach (string source in sourceDirectories)
             {
                 // Remove common root path
-                string sourceSubDir = GetSourceSubDir(source, targetDir);
+                string sourceSubDir = GetSourceSubDir(source, rootTargetDir);
 
                 // Append source sub-dir to target
-                string sourceDirInTarget = Path.Combine(targetDir, sourceSubDir);
+                string sourceDirInTarget = Path.Combine(rootTargetDir, sourceSubDir);
 
                 dirs.Add(sourceDirInTarget);
             }
@@ -160,8 +160,9 @@ namespace BackupUtilityCore.Tasks
                 // Only sub-dir name will match (ignore case), full paths are from different locations
                 bool remove = !sourceDirectories.Any(source => string.Compare(source.Name, target.Name, true) == 0);
 
-                // Remove if directory is now excluded, but not overridden by a source
-                remove |= BackupSettings.IsDirectoryExcluded(target.Name) && !sourceDirsInTarget.Any(s => s.StartsWith(target.FullName, StringComparison.OrdinalIgnoreCase));
+                // Remove if directory is in exclusion list,
+                // unless the dir is configured as a source directory (overriding the exclusion)
+                remove |= BackupSettings.IsDirectoryExcluded(target.Name) && !targetDirs.Any(s => s.StartsWith(target.FullName, StringComparison.OrdinalIgnoreCase));
 
                 // Remove if hidden options changed
                 remove |= BackupSettings.IgnoreHiddenFiles && (target.Attributes & FileAttributes.Hidden) > 0;

--- a/BackupUtilityCore/Tasks/BackupTaskSync.cs
+++ b/BackupUtilityCore/Tasks/BackupTaskSync.cs
@@ -25,9 +25,6 @@ namespace BackupUtilityCore.Tasks
         {
             string targetDir = BackupSettings.TargetDirectory;
 
-            // Get target location of source directories
-            sourceDirsInTarget = GetSourceSubDirs(BackupSettings.SourceDirectories, targetDir);
-
             AddToLog("TARGET", targetDir);
 
             DirectoryInfo targetDirInfo = new(targetDir);
@@ -37,13 +34,11 @@ namespace BackupUtilityCore.Tasks
             {
                 targetDirInfo.Create();
             }
-            else
-            {
-                // Remove directories no longer in config
-                RemoveOrphanedBranches(sourceDirsInTarget, targetDirInfo);
-            }
 
             int backupCount = 0;
+
+            // Get target location of source directories
+            sourceDirsInTarget = GetSourceSubDirs(BackupSettings.SourceDirectories, targetDir);
 
             // Should be same, but safety check
             int maxSource = Math.Min(BackupSettings.SourceDirectories.Length, sourceDirsInTarget.Length);
@@ -81,34 +76,6 @@ namespace BackupUtilityCore.Tasks
             }
 
             return [.. dirs];
-        }
-
-        /// <summary>
-        /// Removes directories from branches in target that are no longer in any source directories.
-        /// </summary>
-        private void RemoveOrphanedBranches(string[] sourceSubDirs, DirectoryInfo targetDirInfo)
-        {
-            // Get current target directories
-            DirectoryInfo[] targetDirectories = [.. targetDirInfo.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)];
-
-            // Need to check for directories that exist in target but not in source
-            foreach (DirectoryInfo targetSubInfo in targetDirectories)
-            {
-                // Check for sub directory in sources
-                string? targetSub = sourceSubDirs.FirstOrDefault(s => s.StartsWith(targetSubInfo.FullName, StringComparison.OrdinalIgnoreCase));
-
-                // If directory not found, then orphaned - delete
-                // Otherwise, keep searching branch until full directories match
-                if (string.IsNullOrEmpty(targetSub))
-                {
-                    DeleteDirectory(targetSubInfo);
-                }
-                else if (targetSub.Length != targetSubInfo.FullName.Length)
-                {
-                    // if not the same dir as source, keep checking sub directories
-                    RemoveOrphanedBranches(sourceSubDirs, targetSubInfo);
-                }
-            }
         }
 
         /// <summary>

--- a/BackupUtilityCore/Tasks/BackupTaskSync.cs
+++ b/BackupUtilityCore/Tasks/BackupTaskSync.cs
@@ -13,21 +13,14 @@ namespace BackupUtilityCore.Tasks
         protected override BackupType BackupType => BackupType.Sync;
 
         /// <summary>
-        /// Target locations of source directories
-        /// </summary>
-        private string[] targetDirs = [];
-
-        /// <summary>
         /// Syncs target directory with source directories.
         /// </summary>
         /// <returns>Number of new files backed up</returns>
         protected override int PerformBackup()
         {
-            string rootTargetDir = BackupSettings.TargetDirectory;
+            AddToLog("TARGET", BackupSettings.TargetDirectory);
 
-            AddToLog("TARGET", rootTargetDir);
-
-            DirectoryInfo targetDirInfo = new(rootTargetDir);
+            DirectoryInfo targetDirInfo = new(BackupSettings.TargetDirectory);
 
             // Check to create target directory
             if (!targetDirInfo.Exists)
@@ -37,45 +30,17 @@ namespace BackupUtilityCore.Tasks
 
             int backupCount = 0;
 
-            // Get target location of source directories
-            targetDirs = GetTargetDirsFromSourceDirs(BackupSettings.SourceDirectories, rootTargetDir);
-
-            // Should be same, but safety check
-            int maxSource = Math.Min(BackupSettings.SourceDirectories.Length, targetDirs.Length);
-
             // Sync each source directory
-            for (int i = 0; i < maxSource; i++)
+            foreach (string sourceDir in BackupSettings.SourceDirectories)
             {
-                string sourceDir = BackupSettings.SourceDirectories[i];
-
                 AddToLog("SOURCE", sourceDir);
 
-                // Sync within the source directories
-                backupCount += SyncDirectories(sourceDir, targetDirs[i]);
+                string targetDir = GetTargetDirForSourceDir(sourceDir, BackupSettings.TargetDirectory);
+
+                backupCount += SyncDirectories(sourceDir, targetDir);
             }
 
             return backupCount;
-        }
-
-        /// <summary>
-        /// Gets the sub directory where each source will be located in the target directory.
-        /// </summary>
-        private static string[] GetTargetDirsFromSourceDirs(string[] sourceDirectories, string rootTargetDir)
-        {
-            List<string> dirs = [];
-
-            foreach (string source in sourceDirectories)
-            {
-                // Remove common root path
-                string sourceSubDir = GetSourceSubDir(source, rootTargetDir);
-
-                // Append source sub-dir to target
-                string sourceDirInTarget = Path.Combine(rootTargetDir, sourceSubDir);
-
-                dirs.Add(sourceDirInTarget);
-            }
-
-            return [.. dirs];
         }
 
         /// <summary>
@@ -139,20 +104,16 @@ namespace BackupUtilityCore.Tasks
         /// </summary>
         private void DeleteSourceDirectoriesFromTarget(DirectoryInfo sourceDirInfo, DirectoryInfo targetDirInfo)
         {
-            // Get current source directories
+            // Get current source sub directories
             DirectoryInfo[] sourceDirectories = [.. sourceDirInfo.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)];
 
-            // Delete missing ones
-            DeleteSourceDirectoriesFromTarget(sourceDirectories, targetDirInfo);
-        }
-
-        /// <summary>
-        /// Deletes any directories in the target directory that are not listed in source array.
-        /// </summary>
-        private void DeleteSourceDirectoriesFromTarget(DirectoryInfo[] sourceDirectories, DirectoryInfo targetDirInfo)
-        {
-            // Get current target directories
+            // Get current target sub directories
             DirectoryInfo[] targetDirectories = [.. targetDirInfo.EnumerateDirectories("*", SearchOption.TopDirectoryOnly)];
+
+            // Get any source directories that are sub directories of the current source dir
+            var directoryOverrides = BackupSettings.SourceDirectories.Where(s => s.Length > sourceDirInfo.FullName.Length && s.StartsWith(sourceDirInfo.FullName, StringComparison.OrdinalIgnoreCase))
+                        // Convert to target paths for comparison
+                        .Select(s => GetTargetDirForSourceDir(s, BackupSettings.TargetDirectory));
 
             // Need to check for directories that exist in target but not in source
             foreach (DirectoryInfo target in targetDirectories)
@@ -161,8 +122,8 @@ namespace BackupUtilityCore.Tasks
                 bool remove = !sourceDirectories.Any(source => string.Compare(source.Name, target.Name, true) == 0);
 
                 // Remove if directory is in exclusion list,
-                // unless the dir is configured as a source directory (overriding the exclusion)
-                remove |= BackupSettings.IsDirectoryExcluded(target.Name) && !targetDirs.Any(s => s.StartsWith(target.FullName, StringComparison.OrdinalIgnoreCase));
+                // unless the dir is configured directly as a source directory (overriding the exclusion)
+                remove |= BackupSettings.IsDirectoryExcluded(target.Name) && !directoryOverrides.Any(s => s.StartsWith(target.FullName, StringComparison.OrdinalIgnoreCase));
 
                 // Remove if hidden options changed
                 remove |= BackupSettings.IgnoreHiddenFiles && (target.Attributes & FileAttributes.Hidden) > 0;

--- a/BackupUtilityTest/BackupUtilityTest.csproj
+++ b/BackupUtilityTest/BackupUtilityTest.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/freedom35/backup-util-dotnet-core</RepositoryUrl>
     <Description>Unit tests for BackupUtilityCore app</Description>
     <PackageLicenseFile></PackageLicenseFile>
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/BackupUtilityTest/Helper/TestBackup.cs
+++ b/BackupUtilityTest/Helper/TestBackup.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BackupUtilityTest.Helper
+{
+    /// <summary>
+    /// Class to help verify backup results.
+    /// </summary>
+    public static class TestBackup
+    {
+        public static int Verify(IEnumerable<string> sourceFiles, string rootTargetDir)
+        {
+            // Get all the target files
+            var targetFiles = Directory.EnumerateFiles(rootTargetDir, "*.*", SearchOption.AllDirectories);
+
+            // Remove target root from paths
+            var targetFilesWithoutRoots = targetFiles.Select(f => f[rootTargetDir.Length..].TrimStart('\\', '/')).ToArray();
+
+            // Get length of root string to be removed
+            int rootSourceLength = TestDirectory.IndexOfSourceSubDir(sourceFiles.First(), rootTargetDir);
+
+            // Compare directories
+            foreach (string file in sourceFiles)
+            {
+                // Remove source root
+                string sourceFileWithoutRoot = file[rootSourceLength..];
+
+                // Check it was copied
+                Assert.IsTrue(targetFilesWithoutRoots.Contains(sourceFileWithoutRoot));
+            }
+
+            return targetFiles.Count();
+        }
+    }
+}

--- a/BackupUtilityTest/Tasks/TestBackupTaskCopy.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskCopy.cs
@@ -3,7 +3,6 @@ using BackupUtilityCore.Tasks;
 using BackupUtilityTest.Helper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -27,6 +26,12 @@ namespace BackupUtilityTest.Tasks
             }
 
             testRoot = Path.Combine(testContext.TestRunDirectory, "TestBackupTaskCopy");
+        }
+
+        [ClassCleanup()]
+        public static void CleanupTest()
+        {
+            Directory.Delete(testRoot, true);
         }
 
         [TestMethod]
@@ -53,9 +58,6 @@ namespace BackupUtilityTest.Tasks
                 MinFileWriteWaitTime = 0
             };
 
-            // Add handler to main copy test for debugging output
-            task.Log += Task_Log;
-
             /////////////////////////////////////
             // Copy files
             /////////////////////////////////////
@@ -68,7 +70,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -82,7 +84,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -106,7 +108,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(2, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -122,7 +124,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(1, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -138,13 +140,10 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Target should have one more file than source
             Assert.AreEqual(sourceFiles.Count() + 1, targetCount);
-
-            // Remove handler
-            task.Log -= Task_Log;
         }
 
         [TestMethod]
@@ -185,7 +184,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -231,7 +230,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -277,39 +276,65 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
         }
 
-        private static int VerifyBackup(IEnumerable<string> sourceFiles, string rootTargetDir)
+        /// <summary>
+        /// Tests excluded directories in config are overridden from direct source directories.
+        /// </summary>
+        [TestMethod]
+        public void TestBackupCopyExcludeDirectoryOverride()
         {
-            // Get all the target files
-            var targetFiles = Directory.EnumerateFiles(rootTargetDir, "*.*", SearchOption.AllDirectories);
+            string rootWorkingDir = Path.Combine(testRoot, "BackupCopyExcludeDirOverride");
 
-            // Remove target root from paths
-            var targetFilesWithoutRoots = targetFiles.Select(f => f[rootTargetDir.Length..].TrimStart('\\', '/')).ToArray();
+            var dirs = TestDirectory.Create(rootWorkingDir);
 
-            // Get length of root string to be removed
-            int rootSourceLength = TestDirectory.IndexOfSourceSubDir(sourceFiles.First(), rootTargetDir);
+            string rootSourceDir = dirs.Item1;
+            string rootTargetDir = dirs.Item2;
+
+            // Create file in bin to test override
+            string rootSourceDirBin = Path.Combine(rootSourceDir, "bin");
+            Directory.CreateDirectory(rootSourceDirBin);
+            TestFile.Create(Path.Combine(rootSourceDirBin, $"bin-file.txt"));
+
+            // Create sub folder/file
+            string rootSourceDirBinDebug = Path.Combine(rootSourceDirBin, "debug");
+            Directory.CreateDirectory(rootSourceDirBinDebug);
+            TestFile.Create(Path.Combine(rootSourceDirBinDebug, $"debug-file.txt"));
+
+
+            // Create settings
+            BackupSettings settings = new()
+            {
+                IgnoreHiddenFiles = false,
+                TargetDirectory = rootTargetDir,
+                SourceDirectories = [rootSourceDir, rootSourceDirBin],
+                ExcludedDirectories = ["bin"]
+            };
+
+            BackupTaskCopy task = new()
+            {
+                RetryEnabled = false,
+                MinFileWriteWaitTime = 0
+            };
+
+            // Copy files
+            int filesCopied = task.Run(settings);
+
+            // All source files should have been copied
+            var sourceFiles = Directory.EnumerateFiles(rootSourceDir, "*.*", SearchOption.AllDirectories);//.Where(sourceFilter);
+
+            // Check task returned expected number of files
+            Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            foreach (string file in sourceFiles)
-            {
-                // Remove source root
-                string sourceFileWithoutRoot = file[rootSourceLength..];
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
-                // Check it was copied
-                Assert.IsTrue(targetFilesWithoutRoots.Contains(sourceFileWithoutRoot));
-            }
-
-            return targetFiles.Count();
-        }
-
-        private void Task_Log(object sender, MessageEventArgs e)
-        {
-            System.Diagnostics.Debug.WriteLine($"COPY-TEST: {e}");
+            // Check expected number of files were copied
+            Assert.AreEqual(sourceFiles.Count(), targetCount);
         }
     }
 }

--- a/BackupUtilityTest/Tasks/TestBackupTaskCopy.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskCopy.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace BackupUtilityTest
+namespace BackupUtilityTest.Tasks
 {
     /// <summary>
     /// Test cases for BackupUtilityCore.Tasks.BackupTaskCopy

--- a/BackupUtilityTest/Tasks/TestBackupTaskIsolatedCopy.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskIsolatedCopy.cs
@@ -29,6 +29,12 @@ namespace BackupUtilityTest.Tasks
             testRoot = Path.Combine(testContext.TestRunDirectory, "TestBackupIsolatedCopy");
         }
 
+        [ClassCleanup()]
+        public static void CleanupTest()
+        {
+            Directory.Delete(testRoot, true);
+        }
+
         [DataRow("2020-04-17 233102", true)]
         [DataRow("2021-01-16 105104-1", true)]
         [DataRow("2019-12-23 015959-2", true)]
@@ -40,12 +46,14 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(shouldParse, BackupTaskIsolatedCopy.TryParseDateFromIsolatedDirectory(dir, out DateTime _));
         }
 
+        [DataRow("2020-04-17 233102", 2020, 4, 17, 23, 31, 2)]
+        [DataRow("2025-11-02 121242", 2025, 11, 2, 12, 12, 42)]
         [TestMethod]
-        public void TestTryParseCorrectDate()
+        public void TestTryParseCorrectDate(string dir, int year, int month, int day, int hour, int minute, int second)
         {
-            Assert.IsTrue(BackupTaskIsolatedCopy.TryParseDateFromIsolatedDirectory("2020-04-17 233102", out DateTime dirDate));
+            Assert.IsTrue(BackupTaskIsolatedCopy.TryParseDateFromIsolatedDirectory(dir, out DateTime dirDate));
 
-            DateTime correctDate = new(2020, 04, 17, 23, 31, 2);
+            DateTime correctDate = new(year, month, day, hour, minute, second);
 
             Assert.AreEqual(correctDate.Year, dirDate.Year);
             Assert.AreEqual(correctDate.Month, dirDate.Month);
@@ -79,9 +87,6 @@ namespace BackupUtilityTest.Tasks
                 RetryEnabled = false,
                 MinFileWriteWaitTime = 0
             };
-
-            // Add handler for debug
-            task.Log += Task_Log;
 
             ///////////////////////////////////////////
             // Copy files
@@ -139,13 +144,6 @@ namespace BackupUtilityTest.Tasks
 
             // Verify 'old' backup no longer exists
             Assert.IsFalse(Directory.Exists(newDateDir));
-
-            ///////////////////////////////////////////
-            // Cleanup
-            ///////////////////////////////////////////
-
-            // Remove handler
-            task.Log -= Task_Log;
         }
 
         private static string VerifyLatestBackup(IEnumerable<string> sourceFiles, string rootTargetDir, int filesCopied)
@@ -188,11 +186,6 @@ namespace BackupUtilityTest.Tasks
             }
 
             return dateSubDir;
-        }
-
-        private void Task_Log(object sender, MessageEventArgs e)
-        {
-            System.Diagnostics.Debug.WriteLine($"ISO-COPY-TEST: {e}");
         }
     }
 }

--- a/BackupUtilityTest/Tasks/TestBackupTaskIsolatedCopy.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskIsolatedCopy.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace BackupUtilityTest
+namespace BackupUtilityTest.Tasks
 {
     /// <summary>
     /// Test cases for BackupUtilityCore.Tasks.BackupTaskIsolatedCopy

--- a/BackupUtilityTest/Tasks/TestBackupTaskSync.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskSync.cs
@@ -3,7 +3,6 @@ using BackupUtilityCore.Tasks;
 using BackupUtilityTest.Helper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -27,6 +26,12 @@ namespace BackupUtilityTest.Tasks
             }
 
             testRoot = Path.Combine(testContext.TestRunDirectory, "TestBackupTaskSync");
+        }
+
+        [ClassCleanup()]
+        public static void CleanupTest()
+        {
+            Directory.Delete(testRoot, true);
         }
 
         [TestMethod]
@@ -53,9 +58,6 @@ namespace BackupUtilityTest.Tasks
                 MinFileWriteWaitTime = 0
             };
 
-            // Add handler to main copy test for debugging output
-            task.Log += Task_Log;
-
             /////////////////////////////////////
             // Copy files
             /////////////////////////////////////
@@ -68,13 +70,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Run copy again
+            // Run sync again
             /////////////////////////////////////
             filesCopied = task.Run(settings);
 
@@ -82,13 +84,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Add files, run copy again
+            // Add files, run sync again
             /////////////////////////////////////
             // Add first file to root
             string addedFile1 = Path.Combine(rootSourceDir, "added-file1.txt");
@@ -106,13 +108,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(2, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Modify file, run copy again
+            // Modify file, run sync again
             /////////////////////////////////////
             TestFile.Modify(addedFile1);
 
@@ -122,13 +124,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(1, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Delete file, run copy again
+            // Delete file, run sync again
             /////////////////////////////////////
             File.Delete(addedFile1);
 
@@ -138,13 +140,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // File should also have been deleted from target
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Delete directory, run copy again
+            // Delete directory, run sync again
             /////////////////////////////////////
             addedDirInfo.Delete(true);
 
@@ -154,13 +156,13 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Dir and contents should also have been deleted from target
             Assert.AreEqual(sourceFiles.Count(), targetCount);
 
             /////////////////////////////////////
-            // Change hidden files, run copy again
+            // Change hidden files, run sync again
             /////////////////////////////////////
             settings.IgnoreHiddenFiles = true;
 
@@ -177,13 +179,10 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Dir and contents should also have been deleted from target
             Assert.AreEqual(sourceFiles.Count(), targetCount);
-
-            // Remove handler
-            task.Log -= Task_Log;
         }
 
         [TestMethod]
@@ -224,7 +223,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -270,7 +269,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -316,7 +315,82 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
+
+            // Check expected number of files were copied
+            Assert.AreEqual(sourceFiles.Count(), targetCount);
+        }
+
+        /// <summary>
+        /// Tests excluded directories in config are overridden from direct source directories.
+        /// </summary>
+        [TestMethod]
+        public void TestBackupSyncExcludeDirectoryOverride()
+        {
+            string rootWorkingDir = Path.Combine(testRoot, "BackupSyncExcludeDirOverride");
+
+            var dirs = TestDirectory.Create(rootWorkingDir);
+
+            string rootSourceDir = dirs.Item1;
+            string rootTargetDir = dirs.Item2;
+
+            // Create file in root of bin
+            string rootSourceDirBin = Path.Combine(rootSourceDir, "bin");
+            Directory.CreateDirectory(rootSourceDirBin);
+            TestFile.Create(Path.Combine(rootSourceDirBin, $"bin-file.txt"));
+
+            // Create sub folder/file deeper within bin
+            string rootSourceDirBinDebug = Path.Combine(rootSourceDirBin, "debug");
+            Directory.CreateDirectory(rootSourceDirBinDebug);
+            TestFile.Create(Path.Combine(rootSourceDirBinDebug, $"debug-file.txt"));
+
+            // Create settings
+            BackupSettings settings = new()
+            {
+                IgnoreHiddenFiles = false,
+                TargetDirectory = rootTargetDir,
+                SourceDirectories = [rootSourceDir],
+                ExcludedDirectories = []
+            };
+
+            BackupTaskSync task = new()
+            {
+                RetryEnabled = false,
+                MinFileWriteWaitTime = 0
+            };
+
+            // Copy files
+            int filesCopied = task.Run(settings);
+
+            // All source files should have been copied
+            var sourceFiles = Directory.EnumerateFiles(rootSourceDir, "*.*", SearchOption.AllDirectories);
+
+            // Check task returned expected number of files
+            Assert.AreEqual(sourceFiles.Count(), filesCopied);
+
+            // Compare directories
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
+
+            // Check expected number of files were copied
+            Assert.AreEqual(sourceFiles.Count(), targetCount);
+
+            ////////////////////////////////////////////////////////////
+            // Exclude bin, but override with source dir to retain it
+            ////////////////////////////////////////////////////////////
+            settings.ExcludedDirectories = ["bin"];
+            settings.SourceDirectories = [rootSourceDir, rootSourceDirBin];
+
+            // Shoould be 0, as all files already copied
+            filesCopied = task.Run(settings);
+
+            // All source files should have been copied
+            sourceFiles = Directory.EnumerateFiles(rootSourceDir, "*.*", SearchOption.AllDirectories);
+
+            // Check task returned expected number of files
+            Assert.AreEqual(0, filesCopied);
+
+            // Compare directories
+            targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -365,7 +439,7 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(sourceFiles.Count(), filesCopied);
 
             // Compare directories
-            int targetCount = VerifyBackup(sourceFiles, rootTargetDir);
+            int targetCount = TestBackup.Verify(sourceFiles, rootTargetDir);
 
             // Check expected number of files were copied
             Assert.AreEqual(sourceFiles.Count(), targetCount);
@@ -381,39 +455,10 @@ namespace BackupUtilityTest.Tasks
             Assert.AreEqual(0, filesCopied);
 
             // Compare directories
-            targetCount = VerifyBackup(sourceFiles1, rootTargetDir);
+            targetCount = TestBackup.Verify(sourceFiles1, rootTargetDir);
 
             // 2nd dir (no longer in config) and contents should have been preserved - not deleted from target
             Assert.AreEqual(sourceFiles.Count(), targetCount);
-        }
-
-        private static int VerifyBackup(IEnumerable<string> sourceFiles, string rootTargetDir)
-        {
-            // Get all the target files
-            var targetFiles = Directory.EnumerateFiles(rootTargetDir, "*.*", SearchOption.AllDirectories);
-
-            // Remove target root from paths
-            var targetFilesWithoutRoots = targetFiles.Select(f => f[rootTargetDir.Length..].TrimStart('\\', '/')).ToArray();
-
-            // Get length of root string to be removed
-            int rootSourceLength = TestDirectory.IndexOfSourceSubDir(sourceFiles.First(), rootTargetDir);
-
-            // Compare directories
-            foreach (string file in sourceFiles)
-            {
-                // Remove source root
-                string sourceFileWithoutRoot = file[rootSourceLength..];
-
-                // Check it was copied
-                Assert.IsTrue(targetFilesWithoutRoots.Contains(sourceFileWithoutRoot));
-            }
-
-            return targetFiles.Count();
-        }
-
-        private void Task_Log(object sender, MessageEventArgs e)
-        {
-            System.Diagnostics.Debug.WriteLine($"SYNC-TEST: {e}");
         }
     }
 }

--- a/BackupUtilityTest/Tasks/TestBackupTaskSync.cs
+++ b/BackupUtilityTest/Tasks/TestBackupTaskSync.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace BackupUtilityTest
+namespace BackupUtilityTest.Tasks
 {
     /// <summary>
     /// Test cases for BackupUtilityCore.Tasks.BackupTaskSync

--- a/BackupUtilityTest/TestBackupTaskSync.cs
+++ b/BackupUtilityTest/TestBackupTaskSync.cs
@@ -323,9 +323,9 @@ namespace BackupUtilityTest
         }
 
         [TestMethod]
-        public void TestBackupSyncDelete()
+        public void TestBackupSyncRemovedFromConfig()
         {
-            string rootWorkingDir = Path.Combine(testRoot, "BackupSyncDelete");
+            string rootWorkingDir = Path.Combine(testRoot, "BackupSyncRemovedFromConfig");
 
             var dirs = TestDirectory.Create(rootWorkingDir, "Source1");
 
@@ -383,8 +383,8 @@ namespace BackupUtilityTest
             // Compare directories
             targetCount = VerifyBackup(sourceFiles1, rootTargetDir);
 
-            // 2nd dir and contents should also have been deleted from target
-            Assert.AreEqual(sourceFiles1.Count(), targetCount);
+            // 2nd dir (no longer in config) and contents should have been preserved - not deleted from target
+            Assert.AreEqual(sourceFiles.Count(), targetCount);
         }
 
         private static int VerifyBackup(IEnumerable<string> sourceFiles, string rootTargetDir)

--- a/BackupUtilityTest/TestEmbeddedResource.cs
+++ b/BackupUtilityTest/TestEmbeddedResource.cs
@@ -28,6 +28,12 @@ namespace BackupUtilityTest
             Directory.CreateDirectory(testRoot);
         }
 
+        [ClassCleanup()]
+        public static void CleanupTest()
+        {
+            Directory.Delete(testRoot, true);
+        }
+
         [TestMethod]
         public void TestCreateDefaultConfig()
         {

--- a/BackupUtilityTest/TestMessageEventArgs.cs
+++ b/BackupUtilityTest/TestMessageEventArgs.cs
@@ -9,68 +9,52 @@ namespace BackupUtilityTest
     [TestClass]
     public sealed class TestMessageEventArgs
     {
+        [DataRow("message0", "")]
+        [DataRow("message1", "argA")]
+        [DataRow("message2", "argB")]
         [TestMethod]
-        public void TestConstructor()
+        public void TestConstructor(string message, string arg)
         {
-            const string Message = "MSG-TEST";
-            const string Arg = "ARG-TEST";
-
             // Properties readonly - assigned in constructor
-            MessageEventArgs e = new(Message, Arg);
+            MessageEventArgs e = new(message, arg);
 
             // Check properties match
-            Assert.AreEqual(Message, e.Message);
-            Assert.AreEqual(Arg, e.Arg);
+            Assert.AreEqual(message, e.Message);
+            Assert.AreEqual(arg, e.Arg);
         }
 
+        [DataRow("message0", "", "message0")]
+        [DataRow("min", "padding", "min      - padding")]
+        [DataRow("message", "arg", "message  - arg")]
+        [DataRow("message1", "argA", "message1 - argA")]
+        [DataRow("message2", "argB", "message2 - argB")]
+        [DataRow("message3", "argSomethingLonger", "message3 - argSomethingLonger")]
         [TestMethod]
-        public void TestToString()
+        public void TestToString(string message, string arg, string expectedString)
         {
-            // Property readonly - assigned in constructor
-            MessageEventArgs e;
+            MessageEventArgs e = new(message, arg);
 
-            // Check not truncated for base to string
-            e = new MessageEventArgs("Message", "ARG");
-            Assert.AreEqual("Message  - ARG", e.ToString());
-
-            // Check not truncated
-            e = new MessageEventArgs("Message", "###############");
-            Assert.AreEqual("Message  - ###############", e.ToString());
+            // Check string not truncated by default
+            Assert.AreEqual(expectedString, e.ToString());
         }
 
+        [DataRow("message0", "", 5, "message0")]
+        [DataRow("message12", "12", 30, "message12 - 12")]
+        [DataRow("message", "1234567890", 20, "message  - ~34567890")]
+        [DataRow("message1", "1234567890", 20, "message1 - ~34567890")]
+        [DataRow("message10", "1234567890", 20, "message10 - ~4567890")]
+        [DataRow("message", "arg", 0, "message  - arg")]
+        [DataRow("message", "arg", 1, "message  - arg")]
+        [DataRow("message", "arg", -1, "message  - arg")]
+        [DataRow("message", "arg", int.MaxValue - 1, "message  - arg")]
+        [DataRow("message", "arg", int.MaxValue, "message  - arg")]
         [TestMethod]
-        public void TestToStringWithMaxLength()
+        public void TestToStringWithMaxLength(string message, string arg, int maxLength, string expectedString)
         {
-            // Property readonly - assigned in constructor
-            MessageEventArgs e;
+            MessageEventArgs e = new(message, arg);
 
-            // Check not truncated when no arg
-            e = new MessageEventArgs("Message", "");
-            Assert.AreEqual("Message", e.ToString(5));
-
-            // Check truncated from start
-            e = new MessageEventArgs("Message", "1234567890");
-            Assert.AreEqual("Message  - ~34567890", e.ToString(20));
-
-            // Check not truncated When below max
-            e = new MessageEventArgs("Message", "12");
-            Assert.AreEqual("Message  - 12", e.ToString(30));
-
-            // Check edge cases
-            e = new MessageEventArgs("Message", "Arg");
-            Assert.AreEqual("Message  - Arg", e.ToString(0));
-
-            e = new MessageEventArgs("Message", "Arg");
-            Assert.AreEqual("Message  - Arg", e.ToString(1));
-
-            e = new MessageEventArgs("Message", "Arg");
-            Assert.AreEqual("Message  - Arg", e.ToString(-1));
-
-            e = new MessageEventArgs("Message", "Arg");
-            Assert.AreEqual("Message  - Arg", e.ToString(int.MaxValue - 1));
-
-            e = new MessageEventArgs("Message", "Arg");
-            Assert.AreEqual("Message  - Arg", e.ToString(int.MaxValue));
+            // Check truncated from start when length exceeded
+            Assert.AreEqual(expectedString, e.ToString(maxLength));
         }
     }
 }

--- a/BackupUtilityTest/YAML/TestYamlParser.cs
+++ b/BackupUtilityTest/YAML/TestYamlParser.cs
@@ -1,7 +1,7 @@
 using BackupUtilityCore.YAML;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace BackupUtilityTest
+namespace BackupUtilityTest.YAML
 {
     /// <summary>
     /// Test cases for BackupUtilityCore.YAML.YamlParser

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Config files (**YAML**) can be edited using any text editor. See section ***Crea
   
 To build the project you will need the [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0). 
 
-For development and debugging you will need an IDE:  
-- [Visual Studio](https://visualstudio.microsoft.com) is a fully-featured IDE with built-in support for C# and comes pre-packaged with the .NET 10.0 SDK in VS2026 (other versions may require optional install). Versions of Visual Studio are available for both [Windows](https://visualstudio.microsoft.com/vs/) and [Mac](https://visualstudio.microsoft.com/vs/mac/).  
+For development and debugging you will need a code editor:  
+- [Visual Studio](https://visualstudio.microsoft.com) is a fully-featured IDE with built-in support for C# and comes pre-packaged with the .NET 10.0 SDK in VS2026. The latest version of Visual Studio is currently only available for [Windows](https://visualstudio.microsoft.com/vs/), Visual Studio for [Mac](https://devblogs.microsoft.com/visualstudio/visual-studio-for-mac-retirement-announcement/) was retired in August 2024.  
 - [Visual Studio Code](https://code.visualstudio.com) is a more light-weight code editor that supports development via installation of a C# extension. Visual Studio Code is cross-platform with versions available for [Windows, Linux, and Mac](https://code.visualstudio.com/Download).  
 
 <br />
 
 ## Building
-Building the app project will create a **cross-platform DLL** in either the **debug** or **release** directory, depending on your [build options](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build#options).  
+Building the app project will create a **cross-platform DLL** in either the **debug** or **release** directory, depending on your [build options](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build#options).  
 
-You can either build the app from within the IDE menu (if supported) or by running an [SDK command](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-build) from the terminal when the solution or project file is in the current directory.
+You can either build the app from within the IDE menu (if supported) or by running an [SDK command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build) from the terminal when the solution or project file is in the current directory.
 
 **Debug (default build):**
 ```sh
@@ -55,7 +55,7 @@ $ dotnet build -c release
 <br/>
 
 ## Publishing
-Once the .NET SDK has been installed, you can **publish** the app via Visual Studio or the [command line](https://docs.microsoft.com/en-us/dotnet/core/deploying/). This enables you to create an OS specific executable should you wish to do so.  
+Once the .NET SDK has been installed, you can **publish** the app via Visual Studio or the [command line](https://learn.microsoft.com/en-us/dotnet/core/deploying/). This enables you to create an OS specific executable should you wish to do so.  
 
 To publish via the command line, browse to the **BackupUtilityCore** project directory and run one of the following commands, depending on your target OS:
 
@@ -78,7 +78,7 @@ $ dotnet publish -c release -r osx-x64
 ```sh
 $ dotnet publish -c release -r linux-x64
 ```  
-For further options, refer to the [.NET publishing documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/).  
+For further options, refer to the [.NET publishing documentation](https://learn.microsoft.com/en-us/dotnet/core/deploying/).  
 <br />
 
 ## Usage
@@ -91,7 +91,7 @@ The portable app (**backuputil.dll**) can be executed via the .NET framework usi
 $ dotnet backuputil.dll [option] [<filename>]
 ```  
 
-Alternatively, if the project has been [published](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-framework-dependent) to target the local platform, the **publish** directory will also contain a native bootstrap file for executing the app.  
+Alternatively, if the project has been [published](https://learn.microsoft.com/en-us/dotnet/core/deploying/#framework-dependent-deployment) to target the local platform, the **publish** directory will also contain a native bootstrap file for executing the app.  
 
 The specific command line to run the **executable** with vary depending on the OS:
 


### PR DESCRIPTION
Revision to preserve old directories during a 'sync' backup if they have been removed from the config to prevent unintended data loss.