### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-ubuntu.yml
+++ b/.github/workflows/dotnet-ubuntu.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/freedom35/backup-util-dotnet-core/security/code-scanning/2](https://github.com/freedom35/backup-util-dotnet-core/security/code-scanning/2)

To fix this, add an explicit `permissions` block in `.github/workflows/dotnet-ubuntu.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This supports `actions/checkout` and the build/test flow while preventing unnecessary write scopes on `GITHUB_TOKEN`.

**Where to change:** insert the block after the `on:` trigger section and before `jobs:`.

No imports, methods, or additional definitions are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
