### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/freedom35/backup-util-dotnet-core/security/code-scanning/1](https://github.com/freedom35/backup-util-dotnet-core/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (recommended here since there is a single job and no job-specific permission differences are shown).  
For this workflow’s current actions (checkout/build/test), set:

- `contents: read`

This is the minimal least-privilege scope needed for reading repository content and is sufficient for `actions/checkout` in typical CI read scenarios.  
Change `.github/workflows/dotnet-windows.yml` by inserting the block after the trigger section (`on:` …) and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
